### PR TITLE
Fix url defaulting to undefined

### DIFF
--- a/lib/hippie/client.js
+++ b/lib/hippie/client.js
@@ -24,6 +24,7 @@ var expect = require('./expect');
 function Client(app) {
   if (!(this instanceof Client)) return new Client(app);
   this._base = '';
+  this._url = '';
   this.serialize = serializers.raw;
   this.parse = parsers.raw;
   this.middlewares = [];

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -12,4 +12,13 @@ describe('#base', function() {
       done();
     });
   });
+
+  it('uses the base url by default', function(done) {
+    api()
+    .end(function(err, res) {
+      res.request.uri.href.should.eq('http://localhost:' + server.PORT + '/');
+      should.not.exist(err);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Fixes #19

Defaults the url to an empty string, so hippie will still have a valid uri to call.  Allows usage where user wants to use middleware to set the url, or just default to the root path.