### PR TITLE
end() promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,23 @@ hippie()
 .end(fn);
 ```
 
+When no callback is provided, ```end()``` returns a promise.
+
+```js
+hippie()
+.json()
+.get('https://api.github.com/users/vesln')
+.expectValue('details.company', 'Awesome.io')
+.expectValue('repos[0].name', 'hippie')
+.end()
+.then(function(res) {
+  console.log(res);
+})
+.catch(function(err) {
+  console.error(err);
+});
+```
+
 ### #app
 
 Fire up an HTTP app and set its address as a base URL.

--- a/lib/hippie/client.js
+++ b/lib/hippie/client.js
@@ -13,6 +13,7 @@ var http = require('http');
 var serializers = require('./serializers');
 var parsers = require('./parsers');
 var expect = require('./expect');
+var Promise = global.Promise || require('es6-promise').Promise;
 
 /**
  * Client.
@@ -334,14 +335,13 @@ Client.prototype.expectBody = function(expected) {
   };
 });
 
-/**
- * Perform the test.
- *
- * @param {Function} fn
- * @api public
- */
 
-Client.prototype.end = function(end) {
+/**
+ * Prepares options, serializes request body, and calls setup() for middlware
+ * @param {Function} end
+ * @api private
+ */
+Client.prototype.prepare = function(end) {
   var self = this;
 
   this.options.url = self._base + self._url;
@@ -355,6 +355,25 @@ Client.prototype.end = function(end) {
     if (err) return end(err);
     self.options.body = body;
     self.setup(self.options, end);
+  });
+};
+
+/**
+ * Perform the test.
+ *
+ * @param {Function} fn
+ * @api public
+ */
+
+Client.prototype.end = function(end) {
+  if (end) return this.prepare(end);
+
+  var self = this;
+  return new Promise(function(resolve, reject) {
+    self.prepare(function(err, res, body) {
+      if (err) return reject(err);
+      resolve(res);
+    });
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
   "license": "MIT",
   "dependencies": {
     "assertion-error": "~1.0.0",
-    "request": "~2.55.0",
-    "qs": "~0.6.5",
+    "deep-eql": "~0.1.3",
+    "es6-promise": "^3.0.2",
     "pathval": "0.0.1",
-    "deep-eql": "~0.1.3"
+    "qs": "~0.6.5",
+    "request": "~2.55.0"
   }
 }

--- a/test/end.test.js
+++ b/test/end.test.js
@@ -35,4 +35,26 @@ describe('#end', function() {
       done();
     });
   });
+
+  describe('when no callback is provided', function() {
+    it('returns a promise', function(done) {
+      api()
+      .get('/method')
+      .end()
+      .then( function(res) {
+        res.body.should.eq('GET');
+        done();
+      }).catch(done);
+    });
+
+    it('returns a promise that catches request errors', function(done) {
+      hippie()
+      .get('http://invalid.vesln.com')
+      .end()
+      .catch(function(err) {
+        err.should.be.ok;
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Services that make heavy use of ES7's ```async/await``` are by definition promise-heavy, which can make using hippie feel a bit awkward.  Here's a quick example of a typical mocha test in our repos:

```js
it('should do the thing', (done) => {
  app.data.resource.insert(app, {name: "Foo"}).then( insert => {
    hippie(app.server)
    .json()
    .send(insert)
    .put(path)
    .expectStatus(200)
    .end(done);
  }).catch(done);
});
```

Basically, any time you want to do an asynchronous operation in a test, it means an annoying bit of then-catch boilerplate to deal with the promise/callback disconnect.  It's not a huge deal, but it's the kind of thing that ends up being repeated a *lot*.

Contrast this with how the test looks if ```end()``` were to return a promise in the absence of a callback:
```js
it('should do the thing', async () => {
  let insert = await app.data.resource.insert(app, {name: "Foo"})
  return hippie(app.server)
    .json()
    .send(insert)
    .put(path)
    .expectStatus(200)
    .end();
});
```
Certainly cleaner.

In the event of not needing to do an asynchronous operation prior to the test, the syntax becomes even sexier, because it's an inline function:
```js
it('should do the thing', async () =>
   hippie(app.server)
    .json()
    .send(insert)
    .put(path)
    .expectStatus(200)
    .end();
);
```

Since ```end()``` currently requires a callback to use hippie properly, I don't really see this as a breaking change - this only provides a promise in the absence of a callback.

@vesln Thoughts?  Open to suggestions/other approaches on how best to solve.  Given how well this works with ES7, built in promise support just feels "right" to me, so I thought it might belong in the core.
