### PR TITLE
Add expectKey helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ hippie()
 .get('/users/vesln')
 .expectStatus(200)
 .expectHeader('Content-Type', 'application/json; charset=utf-8')
+.expectKey('username')
 .expectValue('username', 'vesln')
 .expectValue('repos[0].name', 'jsmd')
 .expectBody({
@@ -405,6 +406,22 @@ hippie()
 .get('https://api.github.com/users/vesln')
 .expectValue('details.company', 'Awesome.io')
 .expectValue('repos[0].name', 'hippie')
+.end(fn);
+```
+
+For more information about string paths visit
+[pathval](https://github.com/chaijs/pathval).
+
+### #expectKey
+
+Register a string path expectation for a given key.
+
+```js
+hippie()
+.json()
+.get('https://api.github.com/users/vesln')
+.expectKey('details.company')
+.expectKey('repos[0].name')
 .end(fn);
 ```
 

--- a/examples/expectation.js
+++ b/examples/expectation.js
@@ -10,6 +10,7 @@ api()
 .expectStatus(200)
 .expectHeader('Content-Type', 'application/json; charset=utf-8')
 .expectValue('username', 'vesln')
+.expectKey('repos')
 .expectValue('repos[0].name', 'jsmd')
 .expectBody({
   username: 'vesln',

--- a/lib/hippie/client.js
+++ b/lib/hippie/client.js
@@ -297,6 +297,19 @@ Client.prototype.expectValue = function(key, val) {
 };
 
 /**
+ * Set a key expectation.
+ *
+ * @param {String} string path
+ * @returns {Client} self
+ * @api public
+ */
+
+Client.prototype.expectKey = function(key) {
+  this.expect(expect.keyCheck(key));
+  return this;
+};
+
+/**
  * Set a body expectation.
  *
  * @param {Mixed} expectation

--- a/lib/hippie/expect.js
+++ b/lib/hippie/expect.js
@@ -56,6 +56,22 @@ exports.value = function(key, val) {
 };
 
 /**
+ * Return a key expectation.
+ *
+ * @param {String} string path
+ * @returns {Function}
+ * @api public
+ */
+
+exports.keyCheck = function(keyParam) {
+  return function keyCheck(res, body, next) {
+    var value = pathval(keyParam, body);
+    var notUndefined = typeof value !== 'undefined';
+    next(assert(notUndefined, true, 'Key - ' + keyParam));
+  };
+};
+
+/**
  * Return a body expectation.
  *
  * @param {Mixed} expected

--- a/test/expect-key.test.js
+++ b/test/expect-key.test.js
@@ -1,0 +1,31 @@
+
+describe('#expectKey', function() {
+  it('returns an error when the key is missing from the response', function(done) {
+    api()
+    .json()
+    .get('/keys')
+    .expectKey('non_existing')
+    .end(function(err) {
+      err.should.be.ok;
+      done();
+    });
+  });
+
+  it('does not return an error when the key is present', function(done) {
+    api()
+    .json()
+    .get('/keys')
+    .expectKey('hippie')
+    .end(done);
+  });
+
+  it('should work with falsy values if key is present', function(done) {
+    api()
+    .json()
+    .get('/keys')
+    .expectKey('blank')
+    .expectKey('nullable')
+    .expectKey('boolean')
+    .end(done);
+  });
+});

--- a/test/support/server.js
+++ b/test/support/server.js
@@ -48,6 +48,10 @@ app.get('/list', function(req, res) {
   res.json([{ id: 4 }]);
 });
 
+app.get('/keys', function(req, res) {
+  res.json({ hippie: 'cool', blank: '', nullable: null, boolean: false });
+});
+
 app.get('/user', function(req, res) {
   res.json({ id: 4 });
 });


### PR DESCRIPTION
Similar to expectValue, you can use expectKey to assert that the response
body contains a given a key.

This can be very useful when testing against live APIs where data can
change, but the schema should remain the same.