### PR TITLE
Add option to pass multiple headers to the hippie client

### DIFF
--- a/lib/hippie/client.js
+++ b/lib/hippie/client.js
@@ -119,6 +119,24 @@ Client.prototype.header = function(key, val) {
 };
 
 /**
+ * Set multiple headers.
+ *
+ * @param {Object} headers
+ * @returns {Client} self
+ * @api public
+ */
+
+Client.prototype.headers = function(headers) {
+  var self = this;
+  Object.entries(headers).forEach(function(entry) {
+    var key = entry[0];
+    var val = entry[1];
+    self.header(key, val);
+  });
+  return this;
+};
+
+/**
  * Set HTTP method.
  *
  * @param {String} method

--- a/test/header.test.js
+++ b/test/header.test.js
@@ -9,4 +9,18 @@ describe('#header', function() {
       done();
     });
   });
+
+  it('sets multiple headers for the request', function(done) {
+    api()
+    .get('/header')
+    .headers({
+      'X-Custom': 'custom header',
+      'Y-Custom': 'another header',
+    })
+    .end(function(err, res) {
+      should.not.exist(err);
+      res.body.should.eq('custom header');
+      done();
+    });
+  });
 });


### PR DESCRIPTION
I'm trying to build an API automation framework, testing various APIs. There is no set standard for the headers being passed with our requests.

My preference would be to have a common hippie instance, that accepts headers as an object. I can then have a base function which each API could inherit/call:

```js
const baseGetApi = (uri, custom_headers, data) => {
  return api()
    .json()
    .headers(custom_headers)
    .get(uri)
    .send(data);
};


async function getUserData(userDetails = {}) {
  const userHeaders = { auth: "staff", auth-id: 1234 }
  const userResponseData = await baseGetApi('/v1/users', userHeaders, userDetails)
    .expectStatus(200)
    .end()
    .then((res) => {
      const responseBody = JSON.parse(res.body);
      return responseBody;
    });

  return userResponseData;
}
```